### PR TITLE
Initialize a few variables, to silence compiler warnings.

### DIFF
--- a/src/uavcan.c
+++ b/src/uavcan.c
@@ -410,7 +410,7 @@ static void handle_get_node_info_request(CanardInstance* ins, CanardRxTransfer* 
 
 static void handle_restart_node_request(CanardInstance* ins, CanardRxTransfer* transfer)
 {
-    uint64_t magic;
+    uint64_t magic = 0;  // XXX: initialize to avoid compiler warning below
     canardDecodeScalar(transfer, 0, 40, false, &magic);
     if (restart_cb) {
         restart_cb(get_transfer_info(ins, transfer), magic);
@@ -427,7 +427,7 @@ void uavcan_send_restart_response(struct uavcan_transfer_info_s* transfer_info, 
 
 static void handle_file_beginfirmwareupdate_request(CanardInstance* ins, CanardRxTransfer* transfer)
 {
-    uint8_t source_node_id;
+    uint8_t source_node_id = 0;  // XXX: initialize to avoid compiler warning below
     canardDecodeScalar(transfer, 0, 8, false, &source_node_id);
     uint8_t path_len = transfer->payload_len-1;
     char path[201];
@@ -479,7 +479,7 @@ uint8_t uavcan_send_file_read_request(uint8_t remote_node_id, const uint64_t off
 static void handle_file_read_response(CanardInstance* ins, CanardRxTransfer* transfer)
 {
     UNUSED(ins);
-    int16_t error;
+    int16_t error = 0;  // XXX: initialize to avoid compiler warning below
     uint8_t data[256];
     size_t data_len = transfer->payload_len-2;
     canardDecodeScalar(transfer, 0, 16, true, &error);


### PR DESCRIPTION
- These variables do get set by when passed by-reference to canardDecodeScalar()
- No functional changes
- Compile warnings that were being generated:

```
src/uavcan.c: In function 'onTransferReceived':
src/uavcan.c:441:9: warning: 'source_node_id' may be used uninitialized in this function [-Wmaybe-uninitialized]
         file_beginfirmwareupdate_cb(get_transfer_info(ins, transfer), source_node_id, path);
         ^
src/uavcan.c:430:13: note: 'source_node_id' was declared here
     uint8_t source_node_id;
             ^
src/uavcan.c:416:9: warning: 'magic' may be used uninitialized in this function [-Wmaybe-uninitialized]
         restart_cb(get_transfer_info(ins, transfer), magic);
         ^
src/uavcan.c:413:14: note: 'magic' was declared here
     uint64_t magic;
              ^
src/uavcan.c: In function 'handle_file_read_response.isra.2':
src/uavcan.c:492:9: warning: 'error' may be used uninitialized in this function [-Wmaybe-uninitialized]
         file_read_response_cb(transfer->transfer_id, error, data, data_len, data_len<256);
         ^
src/uavcan.c:482:13: note: 'error' was declared here
     int16_t error;
             ^
```