### PR TITLE
Separate build and upload steps for bootloader firmware

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -36,7 +36,7 @@ ELF := $(BUILD_DIR)/bin/main.elf
 BIN := $(BUILD_DIR)/bin/main.bin
 
 .PHONY: all
-all: $(LIBOPENCM3_DIR) $(BIN)
+all: $(LIBOPENCM3_DIR) $(ELF) $(BIN)
 
 $(BUILD_DIR)/bin/%.elf: $(COMMON_OBJS) $(BUILD_DIR)/canard.o
 	@echo "### BUILDING $@"
@@ -64,11 +64,6 @@ $(BUILD_DIR)/canard.o: $(LIBCANARD_DIR)/canard.c
 $(LIBOPENCM3_DIR):
 	@echo "### BUILDING $@"
 	@$(MAKE) -C $(LIBOPENCM3_DIR) $(LIBOPENCM3_MAKE_ARGS)
-
-.PHONY: upload
-upload: $(BUILD_DIR)/bin/main.elf $(BUILD_DIR)/bin/main.bin
-	@echo "### UPLOADING"
-	@openocd -f openocd.cfg -d2 -c "program $< verify reset exit"
 
 .PHONY: clean
 clean:

--- a/rebuild_all.sh
+++ b/rebuild_all.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# Rebuild bootleader firmware for all boards that we care about.
+# Any existing (stale) binaries are deleted before building anything.
+
+declare -a ALL_BOARDS=("com.matternet.carriage_2.0"
+                       "com.matternet.payload_bay_1.0"
+                       "com.matternet.battery_bay_v1_1.0"
+                       "com.matternet.battery_bay_2.0"
+                       "com.matternet.handover_1.0"
+                       "com.matternet.hangar_v2_1.0"
+                       "com.matternet.rfid_access_1.0"
+                       "com.matternet.ucann_1.0"
+                       "com.matternet.bmu-B_1.0"
+                       "com.matternet.external_led_1.0"
+                       )
+
+
+# Delete any pre-existing copies of build targets
+for i in ${!ALL_BOARDS[@]}; do
+    board=${ALL_BOARDS[$i]}
+    builddir="build/${board}_bl/bin"
+    echo "rm -f $builddir/main.*"
+    rm -f ${builddir}/main.*
+done
+
+
+# Build each board target
+for i in ${!ALL_BOARDS[@]}; do
+    board=${ALL_BOARDS[$i]}
+    make BOARD=${board}
+done
+
+
+# Verify Build Success
+num_errors=0
+for i in ${!ALL_BOARDS[@]}; do
+    board=${ALL_BOARDS[$i]}
+    builddir="build/${board}_bl/bin"
+
+    outfile="${builddir}/main.elf"
+    if [ ! -f $outfile ]; then
+        echo "ERROR: Expected output file doesn't exist: $outfile"
+        ((num_errors=num_errors+1))
+    fi
+
+    outfile="${builddir}/main.bin"
+    if [ ! -f $outfile ]; then
+        echo "ERROR: Expected output file doesn't exist: $outfile"
+        ((num_errors=num_errors+1))
+    fi
+done
+
+
+# Cleanup and report errors
+if (( $num_errors > 0 )); then
+    echo "TOTAL ERRORS: $num_errors"
+    exit 1   # TODO: Better error codes?
+fi

--- a/upload_bootloader.sh
+++ b/upload_bootloader.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Upload bootloader firmware to a board.
+# The bootloader binary (.../main.elf) must already exist.
+#
+# Usage examples:
+#   $ ./upload_bootloader.sh openocd_v2-1.cfg com.matternet.rfid_access_1.0
+#   $ ./upload_bootloader.sh openocd_v2-1.cfg com.matternet.battery_bay_2.0
+
+
+usage="$(basename "$0") [-h] <cfg-file> <board-name> -- upload bootloader firmware to a board"
+
+
+# Parse and verify command-line args
+if [ "$1" == "-h" ]; then
+  echo "Usage: $usage"
+  exit 0
+fi
+
+cfgfile=$1
+board=$2
+
+if [ ! -f $cfgfile ]; then
+    echo "ERROR: Config file doesn't exist: $cfgfile"
+    exit 1
+fi
+
+builddir="build/${board}_bl/bin"
+fwfile=${builddir}/main.elf
+if [ ! -f $fwfile ]; then
+    echo "ERROR: Firmware file doesn't exist: $fwfile"
+    exit 1
+fi
+
+
+# Run the upload command
+openocd -f ${cfgfile} -d2 -c "program ${fwfile} verify reset exit"


### PR DESCRIPTION
- Build step uses the Makefile
- Upload step uses a shell script instead of a makefile target
- There is also now a shell script to rebuild all targets of interest
- Reason: This makes it easy to validate all builds, either manually
  in a developer work area or automatically in a Docker container