### PR TITLE
AVX-115 Align bootloader repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "modules/libopencm3"]
 	path = modules/libopencm3
-	url = git@github.com:OpenMotorDrive/libopencm3.git
+	url = git@github.com:matternet/libopencm3.git
 [submodule "modules/libcanard"]
 	path = modules/libcanard
-	url = git@github.com:OpenMotorDrive/libcanard.git
+	url = git@github.com:matternet/libcanard.git


### PR DESCRIPTION
- update git submodules to point to Matternet forks

@afbowen @viet-nguyen-matternet @kuanli1 This is simply updating modules, libopencm3 and libcanard.  Previously, we were pointing to those on OpenMotorDrive.
- libopencm3 was properly forked 
- we've already had the discussion about libcanard with my previous PR